### PR TITLE
Define CD environment in workflow

### DIFF
--- a/.github/workflows/run-action.yaml
+++ b/.github/workflows/run-action.yaml
@@ -10,6 +10,7 @@ on:
 jobs:
   run-action:
     runs-on: windows-2022
+    environment: CD
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -39,6 +40,7 @@ jobs:
 
   run-action-linux:
     runs-on: ubuntu-22.04
+    environment: CD
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/run-action.yaml
+++ b/.github/workflows/run-action.yaml
@@ -1,6 +1,5 @@
 name: run-action
 on:
-  pull_request:
   push:
     branches:
       - main


### PR DESCRIPTION
### Background
This repository currently has code signing secrets available as repo secrets. This is helpful for testing, however it is preferable to have CD secrets available as CD environment secrets.

### Changes
Defined environment in workflow and configured the workflow to run only on push to protected branches. This setup will help us showcase the right way to use this action. 