### PR TITLE
Make `keypair-alias` value a variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The code-sign-action action integrates with Digicert One and uses SignTool on Wi
 - `CERTIFICATE_SHA1_HASH`: SHA1 fingerprint of the code signing certificate.
 - `CLIENT_CERTIFICATE`: Client authentication certificate created for the GitHub Actions service user in Digicert One.(.p12 file)
 - `CLIENT_CERTIFICATE_PASSWORD`: Client authentication certificate password created for the GitHub Actions service user in Digicert One.
+- `KEYPAIR_ALIAS`: Keypair alias value found in the "Keypair details" section of the "Certificates" page in your KeyLocker dashboard.
 
 ### Inputs
 
@@ -41,6 +42,7 @@ jobs:
           CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
         uses: cognitedata/code-sign-action/@v2
         with:
           path-to-binary: 'test\test.dll'
@@ -71,6 +73,7 @@ jobs:
           CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
         uses: cognitedata/code-sign-action/@v2
         with:
           path-to-binary: "test"

--- a/action.yaml
+++ b/action.yaml
@@ -50,7 +50,7 @@ runs:
       env:
         GITHUB_WORKSPACE: ${{ github.workspace }}
       run: |
-        smctl windows certsync --keypair-alias="key_464138416"
+        smctl windows certsync --keypair-alias="${{ env.KEYPAIR_ALIAS }}"
         $file_path = "${{ env.GITHUB_WORKSPACE }}\${{ inputs.path-to-binary }}"
         $files_to_sign = @()
         if (Test-Path -Path $file_path -PathType Leaf) {
@@ -80,7 +80,7 @@ runs:
         file_path="${{ inputs.path-to-binary }}"
         for f in $(find $file_path -type f); do
           echo $f
-          smctl sign -v --keypair-alias="key_464138416" --config-file="/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64/pkcs11properties.cfg" --fingerprint "${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}" --input "$f"
+          smctl sign -v --keypair-alias="${{ env.KEYPAIR_ALIAS }}" --config-file="/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64/pkcs11properties.cfg" --fingerprint "${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}" --input "$f"
         done
       if: runner.os == 'Linux'
       shell: bash


### PR DESCRIPTION
Currently the `keypair-alias` option passed into smctl is hardcoded: https://github.com/cognitedata/code-sign-action/blob/v2/action.yaml#L53

Changing this value to a variable set by the environment allows other developers to use this action in their own projects.

Thanks for putting this together, definitely the clearest example of using DigiCert's KeyLocker in GitHub Actions!