### PR TITLE
[SEC-3551] Use and test new CODE_SIGNING_KEYPAIR_ALIAS parameter

### DIFF
--- a/.github/workflows/run-action.yaml
+++ b/.github/workflows/run-action.yaml
@@ -20,7 +20,8 @@ jobs:
           CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-        uses: cognitedata/code-sign-action/@v2
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+        uses: cognitedata/code-sign-action/@v3-beta.1
         with:
           path-to-binary: 'test\test.dll'
 
@@ -31,7 +32,8 @@ jobs:
           CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-        uses: cognitedata/code-sign-action/@v2
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+        uses: cognitedata/code-sign-action/@v3-beta.1
         with:
           path-to-binary: "test"
 
@@ -49,7 +51,8 @@ jobs:
           CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-        uses: cognitedata/code-sign-action/@v2
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+        uses: cognitedata/code-sign-action/@v3-beta.1
         with:
           path-to-binary: "test/test.dll"
 
@@ -60,6 +63,7 @@ jobs:
           CERTIFICATE_SHA1_HASH: ${{ secrets.CODE_SIGNING_CERT_SHA1_HASH }}
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
-        uses: cognitedata/code-sign-action/@v2
+          KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
+        uses: cognitedata/code-sign-action/@v3-beta.1
         with:
           path-to-binary: "test"

--- a/.github/workflows/run-action.yaml
+++ b/.github/workflows/run-action.yaml
@@ -21,7 +21,7 @@ jobs:
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
           KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
-        uses: cognitedata/code-sign-action/@v3-beta.1
+        uses: cognitedata/code-sign-action/@v3
         with:
           path-to-binary: 'test\test.dll'
 
@@ -33,7 +33,7 @@ jobs:
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
           KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
-        uses: cognitedata/code-sign-action/@v3-beta.1
+        uses: cognitedata/code-sign-action/@v3
         with:
           path-to-binary: "test"
 
@@ -52,7 +52,7 @@ jobs:
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
           KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
-        uses: cognitedata/code-sign-action/@v3-beta.1
+        uses: cognitedata/code-sign-action/@v3
         with:
           path-to-binary: "test/test.dll"
 
@@ -64,6 +64,6 @@ jobs:
           CLIENT_CERTIFICATE: ${{ secrets.CODE_SIGNING_CLIENT_CERT }}
           CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGNING_CLIENT_CERT_PASSWORD }}
           KEYPAIR_ALIAS: ${{ secrets.CODE_SIGNING_KEYPAIR_ALIAS }}
-        uses: cognitedata/code-sign-action/@v3-beta.1
+        uses: cognitedata/code-sign-action/@v3
         with:
           path-to-binary: "test"

--- a/.github/workflows/run-action.yaml
+++ b/.github/workflows/run-action.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - "releases/*"
+      - "release-*"
 
 jobs:
   run-action-windows:

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,7 @@ runs:
         echo "SM_API_KEY=${{ env.CERTIFICATE_HOST_API_KEY }}" >> "$GITHUB_ENV"
         echo "SM_CLIENT_CERT_PASSWORD=${{ env.CLIENT_CERTIFICATE_PASSWORD }}" >> "$GITHUB_ENV"
         echo "SM_CODE_SIGNING_CERT_SHA1_HASH=${{ env.CERTIFICATE_SHA1_HASH }}" >> "$GITHUB_ENV"
+        echo "SM_KEYPAIR_ALIAS=${{ env.KEYPAIR_ALIAS }}" >> "$GITHUB_ENV"
         if [ "${{ runner.os }}" == "Windows" ]
         then
           echo "SM_CLIENT_CERT_FILE=D:\\cognite_code_signing_github_actions.p12" >> "$GITHUB_ENV"
@@ -50,7 +51,7 @@ runs:
       env:
         GITHUB_WORKSPACE: ${{ github.workspace }}
       run: |
-        smctl windows certsync --keypair-alias="${{ env.KEYPAIR_ALIAS }}"
+        smctl windows certsync --keypair-alias="${{ env.SM_KEYPAIR_ALIAS }}"
         $file_path = "${{ env.GITHUB_WORKSPACE }}\${{ inputs.path-to-binary }}"
         $files_to_sign = @()
         if (Test-Path -Path $file_path -PathType Leaf) {
@@ -80,7 +81,7 @@ runs:
         file_path="${{ inputs.path-to-binary }}"
         for f in $(find $file_path -type f); do
           echo $f
-          smctl sign -v --keypair-alias="${{ env.KEYPAIR_ALIAS }}" --config-file="/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64/pkcs11properties.cfg" --fingerprint "${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}" --input "$f"
+          smctl sign -v --keypair-alias="${{ env.SM_KEYPAIR_ALIAS }}" --config-file="/tmp/DigiCert One Signing Manager Tools/smtools-linux-x64/pkcs11properties.cfg" --fingerprint "${{ env.SM_CODE_SIGNING_CERT_SHA1_HASH }}" --input "$f"
         done
       if: runner.os == 'Linux'
       shell: bash


### PR DESCRIPTION
This PR makes necessary changes to release v3 of the Action:

- Change variable names associated with keypair-alias to match convention used in other variables.
- Use the keypair-alias value from the newly available CODE_SIGNING_KEYPAIR_ALIAS secret in tests.